### PR TITLE
Removed the hardcoded IPs

### DIFF
--- a/components/third-party/sonarqube/sonarqube-svc.yml
+++ b/components/third-party/sonarqube/sonarqube-svc.yml
@@ -7,9 +7,6 @@ metadata:
     app.kubernetes.io/instance: sonarqube
   name: sonarqube
 spec:
-  clusterIP: 10.217.4.249
-  clusterIPs:
-  - 10.217.4.249
   internalTrafficPolicy: Cluster
   ipFamilies:
   - IPv4


### PR DESCRIPTION
The hardcoded cluster IPs cause this to fail if the IP range doesn't match. Deleting these lines allows kube to automatically populate it instead.